### PR TITLE
chore: add the .idea and .vscode to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /Cargo.lock
 
 logs
+
+# IDE and editor
+.vscode
+.idea


### PR DESCRIPTION
I checked datafusion and opendal, both of them add the `.idea` and `.vscode` to the gitignore
