### PR TITLE
refactor: use jiff for timestamp 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/cratesland/logforth"
 rust-version = "1.71.0"
-version = "0.8.0"
+version = "0.9.0"
 
 categories = ["development-tools::debugging"]
 keywords = ["logging", "log", "opentelemetry", "fastrace"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,27 +34,27 @@ rustdoc-args = ["--cfg", "docs"]
 
 [features]
 fastrace = ["dep:fastrace"]
-json = ["dep:serde_json", "dep:serde"]
+json = ["dep:serde_json", "dep:serde", "jiff/serde"]
 no-color = ["colored/no-color"]
 opentelemetry = [
   "dep:opentelemetry",
   "dep:opentelemetry-otlp",
   "dep:opentelemetry_sdk",
 ]
-rolling_file = ["dep:crossbeam-channel", "dep:parking_lot", "dep:time"]
+rolling_file = ["dep:crossbeam-channel", "dep:parking_lot"]
 
 [dependencies]
 anyhow = { version = "1.0" }
 colored = { version = "2.1" }
-humantime = { version = "2.1" }
+jiff = { version = "0.1.5" }
 log = { version = "0.4", features = ["std", "kv_unstable"] }
 paste = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-rand = "0.8.5"
-tempfile = "3.3"
+rand = "0.8"
+tempfile = "3.12"
 
 ## Rolling file dependencies
 [dependencies.crossbeam-channel]
@@ -64,11 +64,6 @@ version = "0.5"
 [dependencies.parking_lot]
 optional = true
 version = "0.12"
-
-[dependencies.time]
-features = ["formatting", "parsing", "macros"]
-optional = true
-version = "0.3"
 
 ## Fastrace dependencies
 [dependencies.fastrace]

--- a/examples/json_stdio.rs
+++ b/examples/json_stdio.rs
@@ -23,7 +23,7 @@ fn main() {
         .dispatch(
             Dispatch::new()
                 .filter(LevelFilter::Trace)
-                .layout(JsonLayout)
+                .layout(JsonLayout::default())
                 .append(append::Stdout),
         )
         .apply()

--- a/examples/rolling_file.rs
+++ b/examples/rolling_file.rs
@@ -38,7 +38,7 @@ fn main() {
         .dispatch(
             Dispatch::new()
                 .filter(LevelFilter::Trace)
-                .layout(JsonLayout)
+                .layout(JsonLayout::default())
                 .append(RollingFile::new(writer)),
         )
         .dispatch(Dispatch::new().layout(TextLayout::default()).append(Stdout))

--- a/src/append/fastrace.rs
+++ b/src/append/fastrace.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::SystemTime;
-
+use jiff::Zoned;
 use log::Record;
 
 use crate::append::Append;
@@ -27,7 +26,7 @@ impl Append for FastraceEvent {
     fn append(&self, record: &Record) -> anyhow::Result<()> {
         let message = format!(
             "{} {:>5} {}{}",
-            humantime::format_rfc3339_micros(SystemTime::now()),
+            Zoned::now(),
             record.level(),
             record.args(),
             KvDisplay::new(record.key_values()),

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -24,7 +24,6 @@ pub use self::opentelemetry::OpentelemetryLog;
 pub use self::rolling_file::RollingFile;
 pub use self::stdio::Stderr;
 pub use self::stdio::Stdout;
-
 use crate::layout::IdenticalLayout;
 use crate::layout::Layout;
 

--- a/src/append/rolling_file/clock.rs
+++ b/src/append/rolling_file/clock.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use time::OffsetDateTime;
+use jiff::Timestamp;
 
 #[derive(Debug)]
 pub enum Clock {
@@ -22,16 +22,16 @@ pub enum Clock {
 }
 
 impl Clock {
-    pub fn now(&self) -> OffsetDateTime {
+    pub fn now(&self) -> Timestamp {
         match self {
-            Clock::DefaultClock => OffsetDateTime::now_utc(),
+            Clock::DefaultClock => Timestamp::now(),
             #[cfg(test)]
             Clock::ManualClock(clock) => clock.now(),
         }
     }
 
     #[cfg(test)]
-    pub fn set_now(&mut self, new_time: OffsetDateTime) {
+    pub fn set_now(&mut self, new_time: Timestamp) {
         if let Clock::ManualClock(clock) = self {
             clock.set_now(new_time);
         }
@@ -42,38 +42,38 @@ impl Clock {
 #[derive(Debug)]
 #[cfg(test)]
 pub struct ManualClock {
-    fixed_time: OffsetDateTime,
+    now: Timestamp,
 }
 
 #[cfg(test)]
 impl ManualClock {
-    pub fn new(fixed_time: OffsetDateTime) -> ManualClock {
-        ManualClock { fixed_time }
+    pub fn new(now: Timestamp) -> ManualClock {
+        ManualClock { now }
     }
 
-    fn now(&self) -> OffsetDateTime {
-        self.fixed_time
+    fn now(&self) -> Timestamp {
+        self.now
     }
 
-    pub fn set_now(&mut self, new_time: OffsetDateTime) {
-        self.fixed_time = new_time;
+    pub fn set_now(&mut self, now: Timestamp) {
+        self.now = now;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use time::macros::datetime;
+    use std::str::FromStr;
 
     use super::*;
 
     #[test]
     fn test_manual_clock_adjusting() {
-        let mut clock = ManualClock {
-            fixed_time: datetime!(2023-01-01 12:00:00 UTC),
-        };
-        assert_eq!(clock.now(), datetime!(2023-01-01 12:00:00 UTC));
+        let now = Timestamp::from_str("2023-01-01T12:00:00Z").unwrap();
+        let mut clock = ManualClock { now };
+        assert_eq!(clock.now(), now);
 
-        clock.set_now(datetime!(2024-01-01 12:00:00 UTC));
-        assert_eq!(clock.now(), datetime!(2024-01-01 12:00:00 UTC));
+        let now = Timestamp::from_str("2024-01-01T12:00:00Z").unwrap();
+        clock.set_now(now);
+        assert_eq!(clock.now(), now);
     }
 }

--- a/src/append/rolling_file/clock.rs
+++ b/src/append/rolling_file/clock.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jiff::Timestamp;
+use jiff::Zoned;
 
 #[derive(Debug)]
 pub enum Clock {
@@ -22,18 +22,18 @@ pub enum Clock {
 }
 
 impl Clock {
-    pub fn now(&self) -> Timestamp {
+    pub fn now(&self) -> Zoned {
         match self {
-            Clock::DefaultClock => Timestamp::now(),
+            Clock::DefaultClock => Zoned::now(),
             #[cfg(test)]
             Clock::ManualClock(clock) => clock.now(),
         }
     }
 
     #[cfg(test)]
-    pub fn set_now(&mut self, new_time: Timestamp) {
+    pub fn set_now(&mut self, now: Zoned) {
         if let Clock::ManualClock(clock) = self {
-            clock.set_now(new_time);
+            clock.set_now(now);
         }
     }
 }
@@ -42,20 +42,20 @@ impl Clock {
 #[derive(Debug)]
 #[cfg(test)]
 pub struct ManualClock {
-    now: Timestamp,
+    now: Zoned,
 }
 
 #[cfg(test)]
 impl ManualClock {
-    pub fn new(now: Timestamp) -> ManualClock {
+    pub fn new(now: Zoned) -> ManualClock {
         ManualClock { now }
     }
 
-    fn now(&self) -> Timestamp {
-        self.now
+    fn now(&self) -> Zoned {
+        self.now.clone()
     }
 
-    pub fn set_now(&mut self, now: Timestamp) {
+    pub fn set_now(&mut self, now: Zoned) {
         self.now = now;
     }
 }
@@ -68,12 +68,12 @@ mod tests {
 
     #[test]
     fn test_manual_clock_adjusting() {
-        let now = Timestamp::from_str("2023-01-01T12:00:00Z").unwrap();
-        let mut clock = ManualClock { now };
+        let now = Zoned::from_str("2024-08-10T17:12:52+08[+08]").unwrap();
+        let mut clock = ManualClock { now: now.clone() };
         assert_eq!(clock.now(), now);
 
-        let now = Timestamp::from_str("2024-01-01T12:00:00Z").unwrap();
-        clock.set_now(now);
+        let now = Zoned::from_str("2024-01-01T12:00:00+08[+08]").unwrap();
+        clock.set_now(now.clone());
         assert_eq!(clock.now(), now);
     }
 }

--- a/src/append/rolling_file/rolling.rs
+++ b/src/append/rolling_file/rolling.rs
@@ -277,7 +277,11 @@ impl State {
 
                 if self.log_filename_prefix.is_none()
                     && self.log_filename_suffix.is_none()
-                    && Zoned::strptime(self.date_format, filename).is_err()
+                    && Zoned::strptime(
+                        format!("{} %:z", self.date_format),
+                        format!("{filename} +00:00"),
+                    )
+                    .is_err()
                 {
                     return None;
                 }

--- a/src/append/rolling_file/rolling.rs
+++ b/src/append/rolling_file/rolling.rs
@@ -275,8 +275,9 @@ impl State {
                     }
                 }
 
-                if self.log_filename_prefix.is_none() && self.log_filename_suffix.is_none()
-                // && Date::parse(filename, &self.date_format).is_err()
+                if self.log_filename_prefix.is_none()
+                    && self.log_filename_suffix.is_none()
+                    && Zoned::strptime(self.date_format, filename).is_err()
                 {
                     return None;
                 }

--- a/src/append/rolling_file/rolling.rs
+++ b/src/append/rolling_file/rolling.rs
@@ -444,7 +444,6 @@ mod tests {
                 let rand_str = generate_random_string();
                 expected_file_size += rand_str.len();
 
-                println!("i: {i}, cur_time: {cur_time}, end_time: {end_time}, expected_file_size: {expected_file_size}");
                 assert_eq!(writer.write(rand_str.as_bytes()).unwrap(), rand_str.len());
                 assert_eq!(writer.state.current_filesize, expected_file_size);
 

--- a/src/append/rolling_file/rolling.rs
+++ b/src/append/rolling_file/rolling.rs
@@ -277,11 +277,7 @@ impl State {
 
                 if self.log_filename_prefix.is_none()
                     && self.log_filename_suffix.is_none()
-                    && Zoned::strptime(
-                        format!("{} %:z", self.date_format),
-                        format!("{filename} +00:00"),
-                    )
-                    .is_err()
+                    && jiff::civil::DateTime::strptime(self.date_format, filename).is_err()
                 {
                     return None;
                 }

--- a/src/append/rolling_file/rotation.rs
+++ b/src/append/rolling_file/rotation.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use time::format_description;
-use time::Duration;
-use time::OffsetDateTime;
-use time::Time;
+use jiff::RoundMode;
+use jiff::Timestamp;
+use jiff::TimestampRound;
+use jiff::ToSpan;
+use jiff::Unit;
 
 /// Defines a fixed period for rolling of a log file.
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -31,71 +32,79 @@ pub enum Rotation {
 }
 
 impl Rotation {
-    pub fn next_date_timestamp(&self, current_date: &OffsetDateTime) -> Option<usize> {
+    pub fn next_date_timestamp(&self, current_date: &Timestamp) -> Option<usize> {
+        let timestamp_round = TimestampRound::new().mode(RoundMode::Trunc);
+
         let next_date = match *self {
-            Rotation::Minutely => *current_date + Duration::minutes(1),
-            Rotation::Hourly => *current_date + Duration::hours(1),
-            Rotation::Daily => *current_date + Duration::days(1),
             Rotation::Never => return None,
-        };
-
-        Some(self.round_date(&next_date).unix_timestamp() as usize)
-    }
-
-    fn round_date(&self, date: &OffsetDateTime) -> OffsetDateTime {
-        match *self {
             Rotation::Minutely => {
-                let time = Time::from_hms(date.hour(), date.minute(), 0)
-                    .expect("invalid time; this is a bug in logforth rolling file appender");
-                date.replace_time(time)
+                (*current_date + 1.minute()).round(timestamp_round.smallest(Unit::Minute))
             }
             Rotation::Hourly => {
-                let time = Time::from_hms(date.hour(), 0, 0)
-                    .expect("invalid time; this is a bug in logforth rolling file appender");
-                date.replace_time(time)
+                (*current_date + 1.hour()).round(timestamp_round.smallest(Unit::Hour))
             }
-            Rotation::Daily => {
-                let time = Time::from_hms(0, 0, 0)
-                    .expect("invalid time; this is a bug in logforth rolling file appender");
-                date.replace_time(time)
-            }
-            Rotation::Never => unreachable!("Rotation::Never is impossible to round."),
+            Rotation::Daily => (*current_date + 1.day()).round(timestamp_round.smallest(Unit::Day)),
         }
+        .expect("invalid time; this is a bug in logforth rolling file appender");
+
+        println!("next_date: {:?}", next_date);
+
+        Some(next_date.as_millisecond() as usize)
     }
 
-    pub fn date_format(&self) -> Vec<format_description::FormatItem<'static>> {
+    pub fn date_format(&self) -> &'static str {
         match *self {
-            Rotation::Minutely => format_description::parse("[year]-[month]-[day]-[hour]-[minute]"),
-            Rotation::Hourly => format_description::parse("[year]-[month]-[day]-[hour]"),
-            Rotation::Daily => format_description::parse("[year]-[month]-[day]"),
-            Rotation::Never => format_description::parse("[year]-[month]-[day]"),
+            Rotation::Minutely => "%F-%H-%M",
+            Rotation::Hourly => "%F-%H",
+            Rotation::Daily => "%F",
+            Rotation::Never => "%F",
         }
-        .expect("failed to create a formatter; this is a bug in logforth rolling file appender")
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use time::macros::datetime;
+    use jiff::civil::date;
+    use jiff::tz::Offset;
+    use jiff::tz::TimeZone;
 
     use super::Rotation;
 
     #[test]
     fn test_next_date_timestamp() {
-        let current_date = datetime!(2024-08-10 17:12:52 +8);
+        let current_date = date(2024, 8, 10)
+            .at(17, 12, 52, 0)
+            .to_zoned(TimeZone::fixed(Offset::constant(8)))
+            .unwrap();
+        let current_date = current_date.timestamp();
 
+        assert_eq!(Rotation::Never.next_date_timestamp(&current_date), None);
+
+        let expected_date = date(2024, 8, 10)
+            .at(17, 13, 0, 0)
+            .to_zoned(TimeZone::fixed(Offset::constant(8)))
+            .unwrap();
         assert_eq!(
             Rotation::Minutely.next_date_timestamp(&current_date),
-            Some(datetime!(2024-08-10 17:13:00 +8).unix_timestamp() as usize)
+            Some(expected_date.timestamp().as_millisecond() as usize)
         );
+
+        let expected_date = date(2024, 8, 10)
+            .at(18, 0, 0, 0)
+            .to_zoned(TimeZone::fixed(Offset::constant(8)))
+            .unwrap();
         assert_eq!(
             Rotation::Hourly.next_date_timestamp(&current_date),
-            Some(datetime!(2024-08-10 18:00:00 +8).unix_timestamp() as usize)
+            Some(expected_date.timestamp().as_millisecond() as usize)
         );
+
+        let expected_date = date(2024, 8, 11)
+            .at(0, 0, 0, 0)
+            .to_zoned(TimeZone::fixed(Offset::constant(8)))
+            .unwrap();
         assert_eq!(
             Rotation::Daily.next_date_timestamp(&current_date),
-            Some(datetime!(2024-08-11 00:00:00 +8).unix_timestamp() as usize)
+            Some(expected_date.timestamp().as_millisecond() as usize)
         );
-        assert_eq!(Rotation::Never.next_date_timestamp(&current_date), None);
     }
 }

--- a/src/append/rolling_file/rotation.rs
+++ b/src/append/rolling_file/rotation.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jiff::RoundMode;
-use jiff::Timestamp;
-use jiff::TimestampRound;
-use jiff::ToSpan;
+use jiff::{RoundMode, ToSpan};
 use jiff::Unit;
+use jiff::Zoned;
+use jiff::ZonedRound;
 
 /// Defines a fixed period for rolling of a log file.
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -32,24 +31,18 @@ pub enum Rotation {
 }
 
 impl Rotation {
-    pub fn next_date_timestamp(&self, current_date: &Timestamp) -> Option<usize> {
-        let timestamp_round = TimestampRound::new().mode(RoundMode::Trunc);
+    pub fn next_date_timestamp(&self, current_date: &Zoned) -> Option<usize> {
+        let timestamp_round = ZonedRound::new().mode(RoundMode::Trunc);
 
         let next_date = match *self {
             Rotation::Never => return None,
-            Rotation::Minutely => {
-                (*current_date + 1.minute()).round(timestamp_round.smallest(Unit::Minute))
-            }
-            Rotation::Hourly => {
-                (*current_date + 1.hour()).round(timestamp_round.smallest(Unit::Hour))
-            }
-            Rotation::Daily => (*current_date + 1.day()).round(timestamp_round.smallest(Unit::Day)),
-        }
-        .expect("invalid time; this is a bug in logforth rolling file appender");
-
-        println!("next_date: {:?}", next_date);
-
-        Some(next_date.as_millisecond() as usize)
+            Rotation::Minutely => (current_date + 1.minute()).round(timestamp_round.smallest(Unit::Minute)),
+            Rotation::Hourly => (current_date + 1.hour()).round(timestamp_round.smallest(Unit::Hour)),
+            Rotation::Daily => (current_date + 1.day()).round(timestamp_round.smallest(Unit::Day)),
+        };
+        let next_date =
+            next_date.expect("invalid time; this is a bug in logforth rolling file appender");
+        Some(next_date.timestamp().as_millisecond() as usize)
     }
 
     pub fn date_format(&self) -> &'static str {
@@ -64,47 +57,35 @@ impl Rotation {
 
 #[cfg(test)]
 mod tests {
-    use jiff::civil::date;
-    use jiff::tz::Offset;
-    use jiff::tz::TimeZone;
+    use std::str::FromStr;
+
+    use jiff::Timestamp;
+    use jiff::Zoned;
 
     use super::Rotation;
 
     #[test]
     fn test_next_date_timestamp() {
-        let current_date = date(2024, 8, 10)
-            .at(17, 12, 52, 0)
-            .to_zoned(TimeZone::fixed(Offset::constant(8)))
-            .unwrap();
-        let current_date = current_date.timestamp();
+        let current_date = Zoned::from_str("2024-08-10T17:12:52+08[+08]").unwrap();
 
         assert_eq!(Rotation::Never.next_date_timestamp(&current_date), None);
 
-        let expected_date = date(2024, 8, 10)
-            .at(17, 13, 0, 0)
-            .to_zoned(TimeZone::fixed(Offset::constant(8)))
-            .unwrap();
+        let expected_date = "2024-08-10T17:13:00+08".parse::<Timestamp>().unwrap();
         assert_eq!(
             Rotation::Minutely.next_date_timestamp(&current_date),
-            Some(expected_date.timestamp().as_millisecond() as usize)
+            Some(expected_date.as_millisecond() as usize)
         );
 
-        let expected_date = date(2024, 8, 10)
-            .at(18, 0, 0, 0)
-            .to_zoned(TimeZone::fixed(Offset::constant(8)))
-            .unwrap();
+        let expected_date = "2024-08-10T18:00:00+08".parse::<Timestamp>().unwrap();
         assert_eq!(
             Rotation::Hourly.next_date_timestamp(&current_date),
-            Some(expected_date.timestamp().as_millisecond() as usize)
+            Some(expected_date.as_millisecond() as usize)
         );
 
-        let expected_date = date(2024, 8, 11)
-            .at(0, 0, 0, 0)
-            .to_zoned(TimeZone::fixed(Offset::constant(8)))
-            .unwrap();
+        let expected_date = "2024-08-11T00:00:00+08".parse::<Timestamp>().unwrap();
         assert_eq!(
             Rotation::Daily.next_date_timestamp(&current_date),
-            Some(expected_date.timestamp().as_millisecond() as usize)
+            Some(expected_date.as_millisecond() as usize)
         );
     }
 }

--- a/src/append/rolling_file/rotation.rs
+++ b/src/append/rolling_file/rotation.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jiff::{RoundMode, ToSpan};
+use jiff::RoundMode;
+use jiff::ToSpan;
 use jiff::Unit;
 use jiff::Zoned;
 use jiff::ZonedRound;
@@ -36,8 +37,12 @@ impl Rotation {
 
         let next_date = match *self {
             Rotation::Never => return None,
-            Rotation::Minutely => (current_date + 1.minute()).round(timestamp_round.smallest(Unit::Minute)),
-            Rotation::Hourly => (current_date + 1.hour()).round(timestamp_round.smallest(Unit::Hour)),
+            Rotation::Minutely => {
+                (current_date + 1.minute()).round(timestamp_round.smallest(Unit::Minute))
+            }
+            Rotation::Hourly => {
+                (current_date + 1.hour()).round(timestamp_round.smallest(Unit::Hour))
+            }
             Rotation::Daily => (current_date + 1.day()).round(timestamp_round.smallest(Unit::Day)),
         };
         let next_date =

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::fmt::Arguments;
-use std::time::SystemTime;
 
 use colored::Color;
 use colored::ColoredString;

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -80,7 +80,7 @@ impl TextLayout {
             Level::Trace => self.colors.trace,
         };
 
-        let time = humantime::format_rfc3339_micros(SystemTime::now());
+        let time = jiff::Zoned::now();
         let level = ColoredString::from(record.level().to_string()).color(color);
         let module = record.module_path().unwrap_or_default();
         let file = record.file().unwrap_or_default();


### PR DESCRIPTION
This closes https://github.com/cratesland/logforth/issues/35.

@1996fanrui if you'd like to implement something more flexible like Logback's and Log4j's PatternLayout, you can try to follow #7.